### PR TITLE
Re issue #10:  Warning occurs on each add to watch window.

### DIFF
--- a/patches/binutils-gdb/008-Avoid-warning-on-every-add-to-watch.patch
+++ b/patches/binutils-gdb/008-Avoid-warning-on-every-add-to-watch.patch
@@ -1,0 +1,22 @@
+diff --git a/gdb/printcmd.c b/gdb/printcmd.c
+index d4a4b9e..32a49f4 100644
+--- a/gdb/printcmd.c
++++ b/gdb/printcmd.c
+@@ -1335,7 +1335,7 @@ set_command (char *exp, int from_tty)
+   struct expression *expr = parse_expression (exp);
+   struct cleanup *old_chain =
+     make_cleanup (free_current_contents, &expr);
+-
++#if 0  /* Insight: Avoid this warning when adding items to watch window */
+   if (expr->nelts >= 1)
+     switch (expr->elts[0].opcode)
+       {
+@@ -1351,7 +1351,7 @@ set_command (char *exp, int from_tty)
+ 	warning
+ 	  (_("Expression is not an assignment (and might have no effect)"));
+       }
+-
++#endif /* Insight: */
+   evaluate_expression (expr);
+   do_cleanups (old_chain);
+ }


### PR DESCRIPTION
Add a new patch file to inhibit warning that is triggered by
adding a new item to the watch window.
  new file:  patches/binutils-gdb/008-Avoid-warning-on-every-add-to-watch.patch
